### PR TITLE
Fix of the last commit

### DIFF
--- a/websites.yaml
+++ b/websites.yaml
@@ -227,7 +227,7 @@
   writeup: https://mi.eng.cam.ac.uk/projects/segnet/#research
   authors: [Alex Kendall, Vijay Badrinarayanan, Roberto Cipolla]
   tags: [deep-learning, cnn, segmentation]
-  uses: [demo, library]
+  uses: [demo, backend-dependent]
 
 - name: "Caffe Demos"
   desc: "Web image classification demo"
@@ -237,7 +237,7 @@
   writeup: http://caffe.berkeleyvision.org/
   authors: [Yangqing Jia]
   tags: [deep-learning, cnn, classification, image-classification]
-  uses: [demo, library]
+  uses: [demo, backend-dependent]
 
 - name: "LSTM Music Maker"
   desc: "How evlolved LSTMS improvise on a melody you specify?"


### PR DESCRIPTION
- Forgot to save the file before committing. In the result the following changes were not merged: 

1) Removed "library" use from "Caffe" and "SegNet" as they were not the actual libraries, but applications making use of them.

2) Added "backend-dependent" tag to uses of "Caffee Demos" and "SegNet" as it requires the user to upload an image, and as so it is not easily reusable.